### PR TITLE
Fixed error with rmtree

### DIFF
--- a/service.py
+++ b/service.py
@@ -222,7 +222,7 @@ def download(id, url, filename, search_string=""):
     ## Cleanup temp dir, we recomend you download/unzip your subs in temp folder and
     ## pass that to XBMC to copy and activate
     if xbmcvfs.exists(__temp__):
-        shutil.rmtree(__temp__)
+        shutil.rmtree(__temp__.encode(sys.getfilesystemencoding()))
     xbmcvfs.mkdirs(__temp__)
 
     filename = os.path.join(__temp__, filename + ".zip")


### PR DESCRIPTION
When temp dir contains files with non-ascii characters in the filename, download fails because `rmtree` would raise an exception

```
13:48:41 T:2664576064   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <type 'exceptions.UnicodeDecodeError'>
    Error Contents: 'ascii' codec can't decode byte 0xe2 in position 33: ordinal not in range(128)
    Traceback (most recent call last):
      File "/home/xbian/.xbmc/addons/service.subtitles.argenteam/service.py", line 321, in <module>
        subs = download(params["id"],params["link"], params["filename"])
      File "/home/xbian/.xbmc/addons/service.subtitles.argenteam/service.py", line 225, in download
        shutil.rmtree(__temp__)
      File "/usr/lib/python2.7/shutil.py", line 241, in rmtree
        fullname = os.path.join(path, name)
      File "/usr/lib/python2.7/posixpath.py", line 80, in join
        path += '/' + b
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 33: ordinal not in range(128)
    -->End of Python script error report <--
```

If we encode `__temp__` before calling `rmtre` the error is fixed.
