### PR TITLE
- Fixed temp path definition to allow rmtree empty the 'temp' folder

### DIFF
--- a/service.py
+++ b/service.py
@@ -24,7 +24,7 @@ __language__ = __addon__.getLocalizedString
 __cwd__ = xbmc.translatePath(__addon__.getAddonInfo('path')).decode("utf-8")
 __profile__ = xbmc.translatePath(__addon__.getAddonInfo('profile')).decode("utf-8")
 __resource__ = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')).decode("utf-8")
-__temp__ = xbmc.translatePath(os.path.join(__profile__, 'temp')).decode("utf-8")
+__temp__ = xbmc.translatePath(os.path.join(__profile__,'temp','')).decode("utf-8")
 
 sys.path.append(__resource__)
 
@@ -193,6 +193,7 @@ def search(item):
 def download(id, url, filename, search_string=""):
     subtitle_list = []
     exts = [".srt", ".sub", ".txt", ".smi", ".ssa", ".ass"]
+    
     ## Cleanup temp dir, we recomend you download/unzip your subs in temp folder and
     ## pass that to XBMC to copy and activate
     if xbmcvfs.exists(__temp__):

--- a/service.py
+++ b/service.py
@@ -24,7 +24,8 @@ __language__ = __addon__.getLocalizedString
 __cwd__ = xbmc.translatePath(__addon__.getAddonInfo('path')).decode("utf-8")
 __profile__ = xbmc.translatePath(__addon__.getAddonInfo('profile')).decode("utf-8")
 __resource__ = xbmc.translatePath(os.path.join(__cwd__, 'resources', 'lib')).decode("utf-8")
-__temp__ = xbmc.translatePath(os.path.join(__profile__,'temp','')).decode("utf-8")
+__temp__ = xbmc.translatePath(os.path.join(__profile__,'temp')).decode("utf-8")
+__temp__ = __temp__ + os.path.sep
 
 sys.path.append(__resource__)
 


### PR DESCRIPTION
My diagnostic of the problem was correct, but the solution was not. So, I investigated a little more and found the real cause.

shutil.rmtree was a little 'picky' when the os.path was provided with only 'temp' on all my Linux and Android Kodi nodes. Adding a null string to the end of temp path bring back de zombie shutil.rmtree and all files are deleted before download new ones.

I returned the cleaning and mkdir calls to your 'download' function, because that's a more efficient way to work compared to Opensubtitles and it has nothing to do with the problem erasing temp.

Cualquier cosa, chiflame. :)
